### PR TITLE
Switch test code to use JDK 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,12 @@ hivemqExtension {
 
 java {
     toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+tasks.compileJava {
+    javaCompiler = javaToolchains.compilerFor {
         languageVersion = JavaLanguageVersion.of(11)
     }
 }


### PR DESCRIPTION
This change updates the Java toolchain to version 21 for running tests while maintaining JDK 11 for compilation to ensure compatibility.