### PR TITLE
Add --project-name to snyk-pr workflow

### DIFF
--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -33,5 +33,5 @@ jobs:
       - name: Check for new issues
         uses: hivemq/hivemq-snyk-composite-action@344969d844a085dfbf2d050e2758d5d356aebea7 # v2
         with:
-          snyk-args: --org=hivemq-os-extensions --configuration-matching=^runtimeClasspath$ -d hivemq-allow-all-extension
+          snyk-args: --org=hivemq-os-extensions --project-name=hivemq-allow-all-extension --configuration-matching=^runtimeClasspath$ -d hivemq-allow-all-extension
           snyk-token: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `--project-name=hivemq-allow-all-extension` flag to `snyk-args` in the snyk-pr workflow

## Test plan
- [ ] Verify the Snyk PR check runs successfully with the new `--project-name` flag