### PR TITLE
[LATEST] PLATFORM: Upgrade toolchain to Java 25

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:

--- a/.github/workflows/releaseExtension.yml
+++ b/.github/workflows/releaseExtension.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
         with:

--- a/.github/workflows/snyk-pr.yml
+++ b/.github/workflows/snyk-pr.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Check for new issues
         uses: hivemq/hivemq-snyk-composite-action@1c18f39e10e7b1d35fa121b91b99c0445b7a4a56 # v2

--- a/.github/workflows/snyk-push.yml
+++ b/.github/workflows/snyk-push.yml
@@ -37,7 +37,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/.github/workflows/snyk-release.yml
+++ b/.github/workflows/snyk-release.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: temurin
           java-version: |
             11
-            21
+            25
 
       - name: Setup Snyk
         uses: snyk/actions/setup@9adf32b1121593767fc3c057af55b55db032dc04 # v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ hivemqExtension {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 


### PR DESCRIPTION
Upgrade the build toolchain to Java 25. Compile target stays at Java 11 for broad compatibility.

Part of INT-8.